### PR TITLE
Add warning banner to state v2 docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -79,6 +79,13 @@ const config = {
         defaultMode: "light",
         respectPrefersColorScheme: true,
       },
+      announcementBar: {
+        id: "v2-docs-warning",
+        content:
+          "You're looking at the Friendly Capthca V2 Docs. If you're looking for the Friendly Captcha V1 Docs you can find  them <a href='https://docs.friendlycaptcha.com'>here</a>.",
+        backgroundColor: "#ffb731",
+        textColor: "#333",
+      },
       // Replace with your project's social card
       image: "img/friendlycaptcha-social-card.png",
       navbar: {


### PR DESCRIPTION
We had a customer accidentally reading the v2 docs which caused some confusion.

This PR adds a warning banner that the user is reading v2 docs.
<img width="998" alt="Screenshot 2024-03-14 at 13 36 42" src="https://github.com/FriendlyCaptcha/friendly-docs/assets/9090706/eddfb34f-ff35-4511-af3e-73f3b370d323">
