### PR TITLE
Enable submit button for errors

### DIFF
--- a/docs/sdk/lifecycle.md
+++ b/docs/sdk/lifecycle.md
@@ -4,7 +4,7 @@ The widget has a fixed set of states it can be in.
 
 Usually the only states you have to care about are the following:
 * `completed`: the captcha has been completed, you can enable the button to submit and verification should pass.
-* `error`: something went wrong. You should disable the submit button.
+* `error`: something went wrong. Enable the button to submit so that the error can be investigated.
 * `expired`: the user waited too long and needs to restart. You should disable the submit button.
 * `destroyed`: You called `destroy()` on the widget which cleans it up entirely, it can no longer be used.
 


### PR DESCRIPTION
Follow up to https://github.com/FriendlyCaptcha/friendly-docs/pull/63

I noticed the lifecycle page has the old advice.

I'm not sure what it should say though. This was what I settled on but happy to have some alternative suggestion..