### PR TITLE
Fix sdk.startmode.md list items

### DIFF
--- a/docs/sdk/reference/sdk.startmode.md
+++ b/docs/sdk/reference/sdk.startmode.md
@@ -12,7 +12,9 @@ sidebar_class_name: sidebar-hidden
 
 The start mode of the widget.
 
-\* `"auto"`<!-- -->: the widget gets activated as soon as it is created. \* `"focus"`<!-- -->: the widget gets activated as soon as the form above it is focused. \* `"none"`<!-- -->: The widget does not get activated automatically at all, the user needs to press the widget (or `.start()` gets called using the Javascript API).
+* `"auto"`<!-- -->: the widget gets activated as soon as it is created. <br> 
+* `"focus"`<!-- -->: the widget gets activated as soon as the form above it is focused. <br> 
+* `"none"`<!-- -->: The widget does not get activated automatically at all, the user needs to press the widget (or `.start()` gets called using the Javascript API).
 
 **Signature:**
 


### PR DESCRIPTION
Fixed list items.

Wrong list items formatting in the documentation page:

<img width="996" height="198" alt="image" src="https://github.com/user-attachments/assets/007ff69b-6bdd-4420-9423-0005a1034e7e" />



<img width="1026" height="262" alt="image" src="https://github.com/user-attachments/assets/5153e119-4655-4304-8227-ccdab5a3f76e" />
